### PR TITLE
Element less containers

### DIFF
--- a/source/typescript/component/component_default_html_handlers.ts
+++ b/source/typescript/component/component_default_html_handlers.ts
@@ -216,7 +216,7 @@ loadHTMLHandlerInternal(
 
             if (node.name == "element") {
 
-                host_node.tag = node.value;
+                (<HTMLContainerNode>host_node).container_tag = node.value;
 
                 return;
             }

--- a/source/typescript/component/component_html.ts
+++ b/source/typescript/component/component_html.ts
@@ -31,16 +31,17 @@ function buildExportableDOMNode(
 
     if (ast.is_container) {
 
-        const
-            ctr = <ContainerDomLiteral>node,
-            ctr_ast = <HTMLContainerNode>ast;
+        const {
+            container_tag,
+            component_names,
+            component_attributes
+        } = <HTMLContainerNode>ast,
+            ctr = <ContainerDomLiteral>node;
 
         ctr.is_container = true;
-        ctr.component_names = ctr_ast.component_names;
-        ctr.component_attribs = ctr_ast.component_attributes;
-
-        if (ctr.tag_name == "CONTAINER")
-            ctr.tag_name = "DIV";
+        ctr.component_names = component_names;
+        ctr.component_attribs = component_attributes;
+        ctr.tag_name = container_tag ?? "DIV";
     }
 
     if (ast.attributes && ast.attributes.length > 0) {

--- a/source/typescript/runtime/runtime_container.ts
+++ b/source/typescript/runtime/runtime_container.ts
@@ -55,7 +55,7 @@ export class WickContainer implements Sparky, ObservableWatcher {
      */
     limit: number;
 
-    /**offset_fractional
+    /**
      * HTML Element bound to the container. 
      */
     ele: HTMLElement;
@@ -96,12 +96,19 @@ export class WickContainer implements Sparky, ObservableWatcher {
      */
     trs_descending: any;
 
+    /**
+     * True if any sub-component ele has been mounted to the DOM.
+     */
+    ELEMENT_CONNECTED: boolean;
     UPDATE_FILTER: boolean;
     DOM_UP_APPENDED: boolean;
     DOM_DN_APPENDED: boolean;
     AUTO_SCRUB: boolean;
     LOADED: boolean;
     SCRUBBING: boolean;
+
+    //Replaces the element with sub-component elements if true.
+    REPLACE_ELEMENT: boolean;
 
     parent: WickRTComponent;
 
@@ -118,6 +125,7 @@ export class WickContainer implements Sparky, ObservableWatcher {
     ) {
 
         this.ele = element;
+
         this.comp_constructors = component_constructors;
         this.comp_attributes = component_attributes || component_attributes_default;
 
@@ -139,7 +147,8 @@ export class WickContainer implements Sparky, ObservableWatcher {
 
         this.trs_ascending = null;
         this.trs_descending = null;
-
+        this.REPLACE_ELEMENT = this.ele.tagName == "NULL";
+        this.ELEMENT_CONNECTED = false;
         this.UPDATE_FILTER = false;
         this.DOM_UP_APPENDED = false;
         this.DOM_DN_APPENDED = false;
@@ -282,7 +291,7 @@ export class WickContainer implements Sparky, ObservableWatcher {
         while (i < max && i < output_length) {
             const node = this.activeComps[i++];
             this.dom_comp.push(node);
-            node.appendToDOM(this.ele);
+            this.append(node);
         }
     }
 
@@ -345,7 +354,7 @@ export class WickContainer implements Sparky, ObservableWatcher {
                 if (!this.DOM_UP_APPENDED) {
 
                     for (let i = 0; i < this.dom_up.length; i++) {
-                        this.dom_up[i].appendToDOM(this.ele);
+                        this.append(this.dom_up[i]);
                         this.dom_up[i].index = -1;
                         this.dom_comp.push(this.dom_up[i]);
                     }
@@ -361,7 +370,7 @@ export class WickContainer implements Sparky, ObservableWatcher {
                 if (!this.DOM_DN_APPENDED) {
 
                     for (let i = 0; i < this.dom_dn.length; i++) {
-                        this.dom_dn[i].appendToDOM(this.ele, this.dom_comp[0].ele);
+                        this.append(this.dom_up[i], this.dom_comp[0].ele);
                         this.dom_dn[i].index = -1;
                     }
 
@@ -557,9 +566,7 @@ export class WickContainer implements Sparky, ObservableWatcher {
                     const os = output[j];
                     os.index = -1;
                     trs_in.pos = getColumnRow(j, this.offset, this.shift_amount);
-
-
-                    os.appendToDOM(this.ele, as.ele);
+                    this.append(os, as.ele);
                     os.transitionIn(Object.assign({}, trs_in), (direction) ? "trs_asc_in" : "trs_dec_in");
                     j++;
                 }
@@ -590,7 +597,7 @@ export class WickContainer implements Sparky, ObservableWatcher {
         }
 
         while (j < output.length) {
-            output[j].appendToDOM(this.ele);
+            this.append(output[j]);
             output[j].index = -1;
             trs_in.pos = getColumnRow(j, this.offset, this.shift_amount);
             output[j].transitionIn(Object.assign({}, trs_in), (direction) ? "arrange" : "arrange");
@@ -610,6 +617,39 @@ export class WickContainer implements Sparky, ObservableWatcher {
         }
 
         return transition;
+    }
+
+    /**
+     * Appends elements to the DOM
+     */
+    append(appending_comp: WickRTComponent, append_before_ele?: HTMLElement) {
+        if (this.REPLACE_ELEMENT) {
+            if (!this.ELEMENT_CONNECTED) {
+                appending_comp.appendToDOM(this.parent.ele, this.ele);
+                this.parent.ele.removeChild(this.ele);
+                this.ELEMENT_CONNECTED = true;
+            } else {
+                if (!append_before_ele) {
+
+                    append_before_ele = this.activeComps[0].ele;
+
+                    for (const { ele } of this.activeComps)
+                        if (!ele.parentElement) break;
+                        else append_before_ele = ele;
+                }
+
+                appending_comp.appendToDOM(this.parent.ele, append_before_ele, true);
+            }
+        } else {
+            appending_comp.appendToDOM(this.ele, append_before_ele);
+        }
+    }
+
+    restoreContainerElement() {
+        if (this.REPLACE_ELEMENT) {
+            this.ELEMENT_CONNECTED = false;
+            this.activeComps[0].ele.replaceWith(this.ele);
+        }
     }
 
     /**
@@ -667,6 +707,9 @@ export class WickContainer implements Sparky, ObservableWatcher {
         const transition = createTransition();
 
         if (new_items.length == 0) {
+
+
+            this.restoreContainerElement();
 
             const sl = this.activeComps.length;
 

--- a/source/typescript/types/binding.ts
+++ b/source/typescript/types/binding.ts
@@ -74,6 +74,7 @@ export const enum BINDING_SELECTOR {
     EXPORT_TO_PARENT = "etp",
     INPUT_VALUE = "imp",
     CONTAINER_USE_IF = "cui",
+    CONTAINER_USE_EMPTY = "cue",
     BINDING_INITIALIZATION = "bin"
 }
 

--- a/source/typescript/types/wick_ast_node_types.ts
+++ b/source/typescript/types/wick_ast_node_types.ts
@@ -200,7 +200,7 @@ export enum HTMLNodeTypeLU {
 
 export interface HTMLNode {
     import_list?: any[];
-    
+
     is_container?: boolean;
     /**
      * If node is a <container> node, gives the numerical
@@ -282,6 +282,11 @@ export interface HTMLTextNode {
 export interface HTMLContainerNode extends HTMLNode {
 
     is_container: true,
+
+    /**
+     * Name of the tag. 
+     */
+    container_tag: string;
     components: Component[],
 
     component_names: string[],

--- a/test/container/container-null-element.spec.js
+++ b/test/container/container-null-element.spec.js
@@ -1,0 +1,68 @@
+/**[API]:testing 
+    Container with attribute element="null" shall not produce a containing
+    element for sub-components, but rather insert sub-component elements directly
+    into the parent component element tree. 
+*/
+
+import wick from "@candlefw/wick";
+import spark from "@candlefw/spark";
+
+const
+    data = { data: [{ name: "1" }, { name: "2" }, { name: "3" }] },
+    comp_data = (await wick(`
+    import { data } from "@model";
+
+    export default <div>
+        <container element=div data=\${ data }>
+            <a>\${ name }</a>
+        </container>
+        <container
+            data=\${ data }>
+            <a>\${ name }</a>
+        </container>
+    </div>`));
+
+console.log(comp_data.class_string);
+
+const
+    comp = new comp_data.class(data),
+    elements = comp.ele.children;
+
+
+
+assert_group("Browser run", sequence, () => {
+
+
+    // first set of container children should appear within the root
+    // element. 
+    assert(elements.length == 4);
+    assert(elements[0].tagName == "A");
+    assert(elements[0].innerHTML == "1");
+    assert(elements[1].tagName == "A");
+    assert(elements[1].innerHTML == "2");
+    assert(elements[2].tagName == "A");
+    assert(elements[2].innerHTML == "3");
+
+    //second set should appear within the container's default
+    // div element
+    assert(elements[3].tagName == "DIV");
+
+    assert(elements[3].children[0].tagName == "A");
+    assert(elements[3].children[0].innerHTML == "1");
+    assert(elements[3].children[1].tagName == "A");
+    assert(elements[3].children[1].innerHTML == "2");
+    assert(elements[3].children[2].tagName == "A");
+    assert(elements[3].children[2].innerHTML == "3");
+
+    //Clearing the elements should leave the default div 
+    data.data = [];
+
+    await spark.sleep(10);
+
+    assert(elements.length == 2);
+    assert(elements[1].tagName == "NULL");
+    assert(elements[1].tagName == "DIV");
+});
+
+
+

--- a/test/container/container-null-element.spec.js
+++ b/test/container/container-null-element.spec.js
@@ -13,25 +13,25 @@ const
     import { data } from "@model";
 
     export default <div>
-        <container element=div data=\${ data }>
+        <container element=null data=\${ data }>
             <a>\${ name }</a>
         </container>
-        <container
-            data=\${ data }>
+        <container data=\${ data }>
             <a>\${ name }</a>
         </container>
-    </div>`));
-
-console.log(comp_data.class_string);
-
-const
+    </div>`)),
     comp = new comp_data.class(data),
     elements = comp.ele.children;
 
 
 
-assert_group("Browser run", sequence, () => {
 
+assert_group("Browser run", sequence, browser, () => {
+    // Force the component connection to enable 
+    // update on model changes.
+    keep: comp.CONNECTED = true;
+    await spark.sleep(50);
+    
 
     // first set of container children should appear within the root
     // element. 
@@ -43,7 +43,7 @@ assert_group("Browser run", sequence, () => {
     assert(elements[2].tagName == "A");
     assert(elements[2].innerHTML == "3");
 
-    //second set should appear within the container's default
+    // second set should appear within the container's default
     // div element
     assert(elements[3].tagName == "DIV");
 
@@ -54,15 +54,27 @@ assert_group("Browser run", sequence, () => {
     assert(elements[3].children[2].tagName == "A");
     assert(elements[3].children[2].innerHTML == "3");
 
-    //Clearing the elements should leave the default div 
-    data.data = [];
+    //Clearing the elements should leave the default null element place holder 
+    keep: data.data = [];
 
-    await spark.sleep(10);
+    //Overcome the default model polling interval of 1000/30 ms
+    await spark.sleep(50);
 
     assert(elements.length == 2);
-    assert(elements[1].tagName == "NULL");
+    assert(elements[0].tagName == "NULL");
+    assert(elements[1].tagName == "DIV");
+
+    keep: data.data = [{ name: 1 }, { name: 2 }, { name: 3 }, { name: 4 }, { name: 5 }];
+
+    await spark.sleep(50);
+
+    assert(elements.length == 6);
+
+    keep: data.data = [];
+
+    await spark.sleep(50);
+
+    assert(elements.length == 2);
+    assert(elements[0].tagName == "NULL");
     assert(elements[1].tagName == "DIV");
 });
-
-
-


### PR DESCRIPTION
Allow a container element, normally a div element that holds the elements of the container's components, to dissolve away when the `elements` attribute is set to `null` and the container has active components. 

### Example: 
Normally the component
```html
<div>
    <container 
        data=${ [{name:"willma"}, {name:"smith"}] }
    >
        <div>${name}</name>
    </container>
</div>
```
will render as

```html
<div>
    <div>
        <div>wilma</div>
        <div>smith</div>
    </div>
</div>
```
With element-less containers the component would be written as
```html
<div>
    <container 
        element=null 
        data=${ [{name:"willma"}, {name:"smith"}] }
    >
        <div>${name}</name>
    </container>
</div>
```

and the rendered result would be
```html
<div>
    <div>wilma</div>
    <div>smith</div>
</div>
```

This PR includes the code for implementing this and a test spec.

